### PR TITLE
docker file

### DIFF
--- a/notification-service/docker-compose.yml
+++ b/notification-service/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: coolguy123
     ports:
-      - "5432:5432"
+      - "5433:5433"
     volumes:
       - db_data:/var/lib/postgresql/data
       - ./database:/docker-entrypoint-initdb.d
@@ -24,7 +24,7 @@ services:
       ASPNETCORE_ENVIRONMENT: "Development"
       ConnectionStrings__NotificationDatabase: "Host=db;Database=wellness_notifications;Username=postgres;Password=coolguy123"
     ports:
-      - "8080:8080"
+      - "8082:8082"
 
 volumes:
   db_data:

--- a/notification-service/docker-compose.yml
+++ b/notification-service/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16
+    container_name: notification-db
+    environment:
+      POSTGRES_DB: wellness_notifications
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: coolguy123
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./database:/docker-entrypoint-initdb.d
+
+  notification-service:
+    build:
+      context: .
+      dockerfile: dockerfile   # or Dockerfile, match your filename
+    depends_on:
+      - db
+    environment:
+      ASPNETCORE_ENVIRONMENT: "Development"
+      ConnectionStrings__NotificationDatabase: "Host=db;Database=wellness_notifications;Username=postgres;Password=coolguy123"
+    ports:
+      - "8080:8080"
+
+volumes:
+  db_data:

--- a/notification-service/dockerfile
+++ b/notification-service/dockerfile
@@ -1,0 +1,34 @@
+# =========
+# BUILD STAGE
+# =========
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Copy everything into the build container
+COPY . .
+
+# Set the working directory to the API project (adjust if path differs)
+WORKDIR /src/src/NotificationService.Api
+
+# Restore and publish
+RUN dotnet restore
+RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
+
+# =========
+# RUNTIME STAGE
+# =========
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+
+# Copy published output from build stage
+COPY --from=build /app/publish ./
+
+# Expose the default ASP.NET Core port (change if your app uses another)
+EXPOSE 8080
+
+# Configure ASP.NET Core URLS (Kestrel) to listen on port 8080
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_ENVIRONMENT=Production
+
+# ENTRYPOINT
+ENTRYPOINT ["dotnet", "NotificationService.Api.dll"]


### PR DESCRIPTION
## Notification Service – Docker Testing Guide

### Prerequisites

- **Docker & Docker Compose** installed (Docker Desktop on Windows).
- You are in the folder: `e:\Cap\AI-Wellness-Platform\notification-service`.

---

## 1. One-time setup

### 1.1 `docker-compose.yml` (should look like this)

```yaml
version: "3.9"

services:
  db:
    image: postgres:16
    container_name: notification-db
    environment:
      POSTGRES_DB: wellness_notifications
      POSTGRES_USER: postgres
      POSTGRES_PASSWORD: coolguy123
    ports:
      - "5432:5432"
    volumes:
      - db_data:/var/lib/postgresql/data
      - ./database:/docker-entrypoint-initdb.d

  notification-service:
    build:
      context: .
      dockerfile: dockerfile
    depends_on:
      - db
    environment:
      ASPNETCORE_ENVIRONMENT: "Development"
      ConnectionStrings__NotificationDatabase: "Host=db;Database=wellness_notifications;Username=postgres;Password=coolguy123"
    ports:
      - "8080:8080"

volumes:
  db_data:
```

> `./database` must contain `01_schema.sql`, `02_stored_procedures.sql`, etc.

---

## 2. Start from a clean state

```bash
cd /e/Cap/AI-Wellness-Platform/notification-service

# Stop stack and remove old volumes (so DB init scripts run)
docker compose down -v

# Build images and start Postgres + Notification API
docker compose up --build
```

Keep this terminal open to watch logs.

---

## 3. Quick health checks

Open a **second** terminal:

```bash
cd /e/Cap/AI-Wellness-Platform/notification-service
```

### 3.1 Ping

```bash
curl http://localhost:8080/api/ping
```

- Expected: `{"message":"pong", ...}`

### 3.2 Health (DB connectivity)

```bash
curl http://localhost:8080/api/health
```

- Expected: `{"status":"Healthy","database":"Connected", ...}`

---

## 4. Test notification preferences

Use a **fixed test user id** (valid GUID):

```bash
TEST_USER_ID=11111111-1111-1111-1111-111111111111
```

### 4.1 Create / update preferences

```bash
curl -X POST "http://localhost:8080/api/notifications/preferences" \
  -H "Content-Type: application/json" \
  -H "X-User-Id: $TEST_USER_ID" \
  -d '{
    "isEnabled": true,
    "preferredTimeUtc": "09:00:00",
    "timezone": "UTC"
  }'
```

- `preferredTimeUtc` must be `"HH:mm:ss"`.
- `timezone` must be non-empty (e.g. `"UTC"`).

### 4.2 Get preferences

```bash
curl -X GET "http://localhost:8080/api/notifications/preferences" \
  -H "Content-Type: application/json" \
  -H "X-User-Id: $TEST_USER_ID"
```

- Expected: 200 with the preferences you just saved.

---

## 5. Test device registration

```bash
curl -X POST "http://localhost:8080/api/notifications/register-device" \
  -H "Content-Type: application/json" \
  -H "X-User-Id: $TEST_USER_ID" \
  -d '{
    "deviceToken": "ExponentPushToken[example-device-token]"
  }'
```

- Expected: 200 with device registration response (no Postgres function errors).

---

## 6. Stopping the stack

In the **compose** terminal (where `docker compose up` is running), press:

```text
Ctrl + C
```

Or from another terminal:

```bash
cd /e/Cap/AI-Wellness-Platform/notification-service
docker compose down
```

---

## 7. Common reset command (if DB scripts change)

Whenever you change SQL in `./database` and want a clean DB:

```bash
cd /e/Cap/AI-Wellness-Platform/notification-service
docker compose down -v
docker compose up --build
```